### PR TITLE
Add few conversion for rpc's types, and `try_trait` feat.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::error;
 use std::fmt;
 use std::io;
+use std::option::NoneError;
 
 use algebra::serialize::SerializationError as JubJubSerializationError;
 
@@ -73,6 +74,12 @@ impl error::Error for Error {
             Error::JubJubSerialization(e) => Some(e),
             _ => None,
         }
+    }
+}
+
+impl From<NoneError> for Error {
+    fn from(_: NoneError) -> Error {
+        Error::Generic
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![feature(maybe_uninit_extra)]
+#![feature(try_trait)]
 
 pub use algebra::curves::jubjub::{JubJubAffine, JubJubProjective};
 pub use algebra::fields::bls12_381::fr::Fr as BlsScalar;

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -83,3 +83,27 @@ impl TryFrom<rpc::Nonce> for Nonce {
         Nonce::from_slice(nonce.bs.as_slice()).ok_or(Error::InvalidParameters)
     }
 }
+
+impl From<&rpc::Scalar> for [u8; 32] {
+    fn from(s: &rpc::Scalar) -> Self {
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&s.data);
+        buf
+    }
+}
+
+impl From<&rpc::CompressedPoint> for [u8; 32] {
+    fn from(s: &rpc::CompressedPoint) -> Self {
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&s.y);
+        buf
+    }
+}
+
+impl From<&rpc::Nonce> for [u8; 24] {
+    fn from(s: &rpc::Nonce) -> Self {
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&s.bs);
+        buf
+    }
+}


### PR DESCRIPTION
Those conversions are needed to have smaller code in the phoenix abi
conversion, since we convert Scalar types (and similar multiple times).

It simplify the code from:
```
  let value_commitment =
    note.value_commitment.as_ref().ok_or(Error::Generic)?;

    let mut value_commitment_buf = [0u8; 32];
    value_commitment_buf.copy_from_slice(&value_commitment.data);
```

to:

```
value_commitment: note.value_commitment.as_ref()?.into()
```