### PR TITLE
Update Kelvin related crates versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Victor Lopez <vhrlopes@gmail.com>"]
 edition = "2018"
 
@@ -29,10 +29,10 @@ sha2 = "0.8"
 prost = "0.6"
 tracing = "0.1"
 hex = "^0.4"
-kelvin = "0.11.2"
-kelvin-radix = "0.7"
-kelvin-hamt = "0.8"
-bytehash = "0.2"
+kelvin = "0.12"
+kelvin-radix = "0.8"
+kelvin-hamt = "0.9"
+bytehash = "0.3"
 lazy_static = "1.4"
 num-traits = "0.2"
 unprolix = "0.1"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use bytehash::ByteHash;
 use kelvin::annotations::Count;
-use kelvin::{Blake2b, Content, Map as _, Root, Sink, Source};
+use kelvin::{Blake2b, Content, Root, Sink, Source};
 use kelvin_hamt::CountingHAMTMap as HAMTMap;
 use kelvin_radix::DefaultRadixMap as RadixMap;
 use rand::Rng;


### PR DESCRIPTION
Also bump signatory version to 2.0.1: this is needed to make phoenix
working with the latest Rusk VM code.

See also: dusk-network/rusk-vm#64