### PR TITLE
Dusk token variations

### DIFF
--- a/src/zk/circuit_marcos.rs
+++ b/src/zk/circuit_marcos.rs
@@ -1,0 +1,2 @@
+/// This file will contain an implementation of the 
+/// different macros to vary the different circuit types

--- a/src/zk/circuit_marcos.rs
+++ b/src/zk/circuit_marcos.rs
@@ -1,2 +1,58 @@
 /// This file will contain an implementation of the 
 /// different macros to vary the different circuit types
+
+use dusk_plonk::constraint_system::StandardComposer;
+use phoenix::{
+    utils, zk, Transaction}
+use crate::{NoteVariant, TransactionItem, ViewKey};
+
+macro_rules! phoenix_tx(inputs, outputs, crossover) {
+    () => { 
+        let mut tx = Transaction::default();
+
+        for i in 0..inputs {
+        let sk = SecretKey::default();
+        let vk = sk.view_key();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = TransparentNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        let input = note.to_transaction_input(merkle_opening, sk).unwrap();
+        tx.push_input(input);
+        }
+    
+        for i in 0..outputs {
+        let sk = SecretKey::default();
+        let vk = sk.view_key();
+        let pk = sk.public_key();
+        let value = 100;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        let output = note.to_transaction_output(value, blinding_factor, pk))
+    
+        tx.push_output(output).unwrap();
+        }
+
+        for i in 0..outputs {
+        let sk = SecretKey::default();
+        let vk = sk.view_key();
+        let pk = sk.public_key();
+        let value = 100;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        let output = note.to_transaction_output(value, blinding_factor, pk))
+        
+        tx.set_crossover;
+        }
+
+
+
+
+
+
+       
+        
+    };
+}
+
+fn send_to_obfuscate_variant! () {
+    
+}

--- a/src/zk/gadgets/mod.rs
+++ b/src/zk/gadgets/mod.rs
@@ -4,6 +4,7 @@ pub use merkle::merkle;
 pub use nullifier::nullifier;
 pub use preimage::input_preimage;
 pub use range::range;
+pub use variants::dusk_tx;
 
 mod balance;
 mod commitment;
@@ -11,3 +12,4 @@ mod merkle;
 mod nullifier;
 mod preimage;
 mod range;
+mod variants;

--- a/src/zk/gadgets/mod.rs
+++ b/src/zk/gadgets/mod.rs
@@ -4,7 +4,7 @@ pub use merkle::merkle;
 pub use nullifier::nullifier;
 pub use preimage::input_preimage;
 pub use range::range;
-pub use variants::dusk_tx;
+pub use crate::dusk_tx;
 
 mod balance;
 mod commitment;
@@ -12,4 +12,5 @@ mod merkle;
 mod nullifier;
 mod preimage;
 mod range;
+#[macro_use]
 mod variants;

--- a/src/zk/gadgets/variants.rs
+++ b/src/zk/gadgets/variants.rs
@@ -2,18 +2,18 @@
 /// different macros to vary the different circuit types
 
 use dusk_plonk::constraint_system::StandardComposer;
-use phoenix::{
-    utils, zk, Transaction}
-use crate::{NoteVariant, TransactionItem, ViewKey};
 
+use crate::{NoteVariant, TransactionItem, ViewKey, Transaction};
 
-macro_rules! dusk_tx(inputs, outputs, crossover) {
-    () => { 
+#[macro_export]
+macro_rules! dusk_tx {
+    ($inputs:expr, $outputs:expr, $crossover:expr) => { 
+        {
         let mut tx = Transaction::default();
         let value = 100;
 
         // The inputs
-        for i in 0..inputs {
+        for i in 0..$inputs {
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
@@ -33,12 +33,13 @@ macro_rules! dusk_tx(inputs, outputs, crossover) {
             output_value = total_output_value/(outputs+1);
         }
         
-        for i in 0..outputs {
+        for i in 0..$outputs {
+
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
         let (note, blinding_factor) = TransparentNote::output(&pk, value);
-        let output = note.to_transaction_output(output_value, blinding_factor, pk))
+        let output = note.to_transaction_output(output_value, blinding_factor, pk)
     
         tx.push_output(output).unwrap();
         }
@@ -47,29 +48,32 @@ macro_rules! dusk_tx(inputs, outputs, crossover) {
         let vk = sk.view_key();
         let pk = sk.public_key();
         let (note, blinding_factor) = TransparentNote::output(&pk, value);
-        let output = note.to_transaction_output(output_value, blinding_factor, pk))
+        let output = note.to_transaction_output(output_value, blinding_factor, pk)
     
         tx.set_fee(output).unwrap();
 
-        if crossover {
+        if $crossover {
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
         let (note, blinding_factor) = TransparentNote::output(&pk, value);
-        let output = note.to_transaction_output(output_value, blinding_factor, pk))
+        let output = note.to_transaction_output(output_value, blinding_factor, pk)
         
         tx.set_crossover(output);
         tx.set_contract_output(output);
         }
 
-        
-
-
 
     };
 
     tx
+    }
 }
 
 
+
+
 #[test]
+fn dusk_tx_test() {
+   
+}

--- a/src/zk/gadgets/variants.rs
+++ b/src/zk/gadgets/variants.rs
@@ -6,53 +6,70 @@ use phoenix::{
     utils, zk, Transaction}
 use crate::{NoteVariant, TransactionItem, ViewKey};
 
-macro_rules! phoenix_tx(inputs, outputs, crossover) {
+
+macro_rules! dusk_tx(inputs, outputs, crossover) {
     () => { 
         let mut tx = Transaction::default();
+        let value = 100;
 
+        // The inputs
         for i in 0..inputs {
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
-        let value = 100;
+        let value = value/inputs;
         let note = TransparentNote::output(&pk, value).0;
         let merkle_opening = crypto::MerkleProof::mock(note.hash());
         let input = note.to_transaction_input(merkle_opening, sk).unwrap();
+        
         tx.push_input(input);
         }
     
+        let total_output_value = 100;
+        let output_value;
+        if crossover {
+            output_value = total_output_value/(outputs+2);
+        } else {
+            output_value = total_output_value/(outputs+1);
+        }
+        
         for i in 0..outputs {
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
-        let value = 100;
         let (note, blinding_factor) = TransparentNote::output(&pk, value);
-        let output = note.to_transaction_output(value, blinding_factor, pk))
+        let output = note.to_transaction_output(output_value, blinding_factor, pk))
     
         tx.push_output(output).unwrap();
         }
 
-        for i in 0..outputs {
         let sk = SecretKey::default();
         let vk = sk.view_key();
         let pk = sk.public_key();
-        let value = 100;
         let (note, blinding_factor) = TransparentNote::output(&pk, value);
-        let output = note.to_transaction_output(value, blinding_factor, pk))
+        let output = note.to_transaction_output(output_value, blinding_factor, pk))
+    
+        tx.set_fee(output).unwrap();
+
+        if crossover {
+        let sk = SecretKey::default();
+        let vk = sk.view_key();
+        let pk = sk.public_key();
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        let output = note.to_transaction_output(output_value, blinding_factor, pk))
         
-        tx.set_crossover;
+        tx.set_crossover(output);
+        tx.set_contract_output(output);
         }
 
-
-
-
-
-
-       
         
+
+
+
     };
+
+    tx
 }
 
-fn send_to_obfuscate_variant! () {
-    
-}
+
+#[test]

--- a/src/zk/merkle.rs
+++ b/src/zk/merkle.rs
@@ -54,3 +54,4 @@ impl Default for ZkMerkleLevel {
         }
     }
 }
+


### PR DESCRIPTION
This PR will implement the macro which creates variants of the dusk token contract. In PR #69, the generic end to end logic for the dusk token contract has been implemented and now we need to have a macro which creates a transaction abstract, with variable inputs and outputs for these token contracts.

This closes #61. 