### PR TITLE
Confidential token circuits

### DIFF
--- a/src/zk/circuits/confidential/mod.rs
+++ b/src/zk/circuits/confidential/mod.rs
@@ -1,0 +1,5 @@
+mod send;
+mod send_to_contract_obfuscated;
+mod send_to_contract_transparent;
+mod withdraw_from_obfuscated;
+mod withdraw_from_contract_to_obfuscated;

--- a/src/zk/circuits/confidential/send_to_contract_obfuscated.rs
+++ b/src/zk/circuits/confidential/send_to_contract_obfuscated.rs
@@ -1,0 +1,117 @@
+use crate::{
+    db, zk::gadgets, BlsScalar, NoteVariant, Transaction, TransactionItem, TransactionOutput,
+};
+use dusk_plonk::constraint_system::StandardComposer;
+use dusk_plonk::proof_system::Proof;
+use kelvin::Blake2b;
+
+/// This gadget constructs the circuit for a "Send To Contract Obfuscated" transaction.
+pub fn send_to_contract_obfuscated_gadget(
+    composer: &mut StandardComposer,
+    crossover: &TransactionOutput,
+    m: &TransactionOutput,
+) {
+    // Crossover
+    gadgets::commitment(composer, crossover);
+    gadgets::range(composer, crossover);
+
+    // M
+    gadgets::commitment(composer, m);
+    gadgets::range(composer, m);
+
+    // Crossover.value - m.value = 0
+    let mut sum = composer.zero_var;
+    let value = composer.add_input(BlsScalar::from(crossover.value()));
+    sum = composer.add(
+        (BlsScalar::one(), sum),
+        (BlsScalar::one(), value),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+    );
+
+    let value = composer.add_input(BlsScalar::from(m.value()));
+    sum = composer.add(
+        (BlsScalar::one(), sum),
+        (-BlsScalar::one(), value),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+    );
+
+    composer.constrain_to_constant(sum, BlsScalar::zero(), BlsScalar::zero());
+
+    // TODO: Prove knowledge of encrypted m.value and m.blinding_factor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto, Note, NoteGenerator, ObfuscatedNote, SecretKey, Transaction, TransparentNote,
+    };
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    #[test]
+    fn test_send_to_contract_obfuscated() {
+        let mut tx = Transaction::default();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = ObfuscatedNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        tx.push_input(note.to_transaction_input(merkle_opening, sk).unwrap())
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.set_contract_output(note.to_transaction_output(value, blinding_factor, pk));
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.set_crossover(note.to_transaction_output(value, blinding_factor, pk));
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 2;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.push_output(note.to_transaction_output(value, blinding_factor, pk))
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 3;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_fee(note.to_transaction_output(value, blinding_factor, pk));
+
+        let mut composer = StandardComposer::new();
+
+        send_to_contract_obfuscated_gadget(
+            &mut composer,
+            &tx.crossover().unwrap(),
+            &tx.contract_output().unwrap(),
+        );
+
+        composer.add_dummy_constraints();
+
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let circuit = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &circuit, &mut transcript.clone());
+
+        assert!(proof.verify(&circuit, &mut transcript, &vk, &composer.public_inputs()));
+    }
+}

--- a/src/zk/circuits/confidential/send_to_contract_transparent.rs
+++ b/src/zk/circuits/confidential/send_to_contract_transparent.rs
@@ -1,0 +1,108 @@
+use crate::{
+    db, zk::gadgets, BlsScalar, NoteVariant, Transaction, TransactionItem, TransactionOutput,
+};
+
+use dusk_plonk::constraint_system::StandardComposer;
+use kelvin::Blake2b;
+
+/// This gadget constructs the circuit for a "Send To Contract Transparent" transaction.
+pub fn send_to_contract_transparent_gadget(
+    composer: &mut StandardComposer,
+    crossover: &TransactionOutput,
+    contract_output: &TransactionOutput,
+) {
+    // Crossover
+    gadgets::commitment(composer, crossover);
+    gadgets::range(composer, crossover);
+
+    // Crossover.value - contract_output.value = 0
+    let mut sum = composer.zero_var;
+    let value = composer.add_input(BlsScalar::from(crossover.value()));
+    sum = composer.add(
+        (BlsScalar::one(), sum),
+        (BlsScalar::one(), value),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+    );
+
+    sum = composer.add(
+        (-BlsScalar::one(), sum),
+        (BlsScalar::one(), composer.zero_var),
+        BlsScalar::zero(),
+        BlsScalar::from(contract_output.value()),
+    );
+
+    composer.constrain_to_constant(sum, BlsScalar::zero(), BlsScalar::zero());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{crypto, Note, NoteGenerator, SecretKey, Transaction, TransparentNote};
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    #[test]
+    fn test_send_to_contract_transparent() {
+        let mut tx = Transaction::default();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = TransparentNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        tx.push_input(note.to_transaction_input(merkle_opening, sk).unwrap())
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_contract_output(note.to_transaction_output(value, blinding_factor, pk));
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_crossover(note.to_transaction_output(value, blinding_factor, pk));
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 2;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.push_output(note.to_transaction_output(value, blinding_factor, pk))
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 3;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_fee(note.to_transaction_output(value, blinding_factor, pk));
+
+        let mut composer = StandardComposer::new();
+
+        send_to_contract_transparent_gadget(
+            &mut composer,
+            &tx.crossover().unwrap(),
+            &tx.contract_output().unwrap(),
+        );
+
+        composer.add_dummy_constraints();
+
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let circuit = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &circuit, &mut transcript.clone());
+
+        assert!(proof.verify(&circuit, &mut transcript, &vk, &composer.public_inputs()));
+    }
+}

--- a/src/zk/circuits/confidential/withdraw_from_contract_to_obfuscated.rs
+++ b/src/zk/circuits/confidential/withdraw_from_contract_to_obfuscated.rs
@@ -1,0 +1,119 @@
+use crate::{
+    db, zk::gadgets, BlsScalar, NoteVariant, PublicKey, Transaction, TransactionItem,
+    TransactionOutput,
+};
+
+use dusk_plonk::constraint_system::StandardComposer;
+use kelvin::Blake2b;
+
+/// This gadget constructs the circuit for a "Withdraw from contract obfuscated" transaction.
+pub fn withdraw_from_contract_to_obfuscated_gadget(
+    composer: &mut StandardComposer,
+    tx: &Transaction,
+    pk: &PublicKey,
+    remainder: &TransactionOutput,
+) {
+    // Fetch M
+    // TODO: fetch M
+    // Prove knowledge of commitment to m
+    // Prove message m is in range
+
+    if remainder.value > 0 {
+        // Prove the knowledge of commitment to remainder
+        gadgets::commitment(composer, remainder);
+        // Prove message remainder is in range
+        gadgets::range(composer, remainder);
+    }
+
+    // Outputs
+    tx.outputs().iter().for_each(|tx_output| {
+        // Commitment preimage knowledge + range proof
+        match tx_output.note() {
+            NoteVariant::Obfuscated(_) => {
+                gadgets::commitment(composer, tx_output);
+                gadgets::range(composer, tx_output);
+            }
+            _ => {}
+        }
+    });
+
+    // Message - remainder - output = 0
+    let mut outputs: Vec<TransactionOutput> = vec![];
+    tx.outputs().iter().for_each(|output| {
+        outputs.push(*output);
+    });
+    outputs.push(*tx.fee());
+    if remainder.value > 0 {
+        outputs.push(*remainder);
+    }
+
+    // TODO: use M as inputs
+    // let mut sum = gadgets::balance(composer, m, &outputs);
+
+    // composer.constrain_to_constant(sum, BlsScalar::zero(), BlsScalar::zero());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto, Note, NoteGenerator, ObfuscatedNote, SecretKey, Transaction, TransparentNote,
+    };
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    #[test]
+    fn test_withdraw_obfuscated() {
+        let mut tx = Transaction::default();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = ObfuscatedNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        tx.push_input(note.to_transaction_input(merkle_opening, sk).unwrap())
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.push_output(note.to_transaction_output(value, blinding_factor, pk))
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 2;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        let remainder = note.to_transaction_output(value, blinding_factor, pk);
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 3;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_fee(note.to_transaction_output(value, blinding_factor, pk));
+
+        let mut composer = StandardComposer::new();
+
+        withdraw_from_contract_to_obfuscated_gadget(&mut composer, &tx, &pk, &remainder);
+
+        composer.add_dummy_constraints();
+
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let circuit = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &circuit, &mut transcript.clone());
+
+        assert!(proof.verify(&circuit, &mut transcript, &vk, &composer.public_inputs()));
+    }
+}
+

--- a/src/zk/circuits/confidential/withdraw_from_obfuscated.rs
+++ b/src/zk/circuits/confidential/withdraw_from_obfuscated.rs
@@ -1,0 +1,118 @@
+use crate::{
+    db, zk::gadgets, BlsScalar, NoteVariant, PublicKey, Transaction, TransactionItem,
+    TransactionOutput,
+};
+
+use dusk_plonk::constraint_system::StandardComposer;
+use kelvin::Blake2b;
+
+/// This gadget constructs the circuit for a "Withdraw from Obfuscated" transaction.
+pub fn withdraw_from_contract_obfuscated_gadget(
+    composer: &mut StandardComposer,
+    tx: &Transaction,
+    pk: &PublicKey,
+    remainder: &TransactionOutput,
+) {
+    // Fetch M
+    // TODO: fetch M
+    // Prove knowledge of commitment to m
+    // Prove message m is in range
+
+    if remainder.value > 0 {
+        // Prove the knowledge of commitment to remainder
+        gadgets::commitment(composer, remainder);
+        // Prove message remainder is in range
+        gadgets::range(composer, remainder);
+    }
+
+    // Outputs
+    tx.outputs().iter().for_each(|tx_output| {
+        // Commitment preimage knowledge + range proof
+        match tx_output.note() {
+            NoteVariant::Obfuscated(_) => {
+                gadgets::commitment(composer, tx_output);
+                gadgets::range(composer, tx_output);
+            }
+            _ => {}
+        }
+    });
+
+    // Message - remainder - output = 0
+    let mut outputs: Vec<TransactionOutput> = vec![];
+    tx.outputs().iter().for_each(|output| {
+        outputs.push(*output);
+    });
+    outputs.push(*tx.fee());
+    if remainder.value > 0 {
+        outputs.push(*remainder);
+    }
+
+    // TODO: use M as inputs
+    // let mut sum = gadgets::balance(composer, m, &outputs);
+
+    // composer.constrain_to_constant(sum, BlsScalar::zero(), BlsScalar::zero());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto, Note, NoteGenerator, ObfuscatedNote, SecretKey, Transaction, TransparentNote,
+    };
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    #[test]
+    fn test_withdraw_obfuscated() {
+        let mut tx = Transaction::default();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = ObfuscatedNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        tx.push_input(note.to_transaction_input(merkle_opening, sk).unwrap())
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.push_output(note.to_transaction_output(value, blinding_factor, pk))
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 2;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        let remainder = note.to_transaction_output(value, blinding_factor, pk);
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 3;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_fee(note.to_transaction_output(value, blinding_factor, pk));
+
+        let mut composer = StandardComposer::new();
+
+        withdraw_from_contract_obfuscated_gadget(&mut composer, &tx, &pk, &remainder);
+
+        composer.add_dummy_constraints();
+
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let circuit = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &circuit, &mut transcript.clone());
+
+        assert!(proof.verify(&circuit, &mut transcript, &vk, &composer.public_inputs()));
+    }
+}

--- a/src/zk/circuits/confidential/withdraw_from_obfuscated_to_contract.rs
+++ b/src/zk/circuits/confidential/withdraw_from_obfuscated_to_contract.rs
@@ -1,0 +1,120 @@
+use crate::{
+    db, zk::gadgets, BlsScalar, NoteVariant, PublicKey, Transaction, TransactionItem,
+    TransactionOutput,
+};
+
+use dusk_plonk::constraint_system::StandardComposer;
+use kelvin::Blake2b;
+
+/// This gadget constructs the circuit for a "Withdraw from contract obfuscated" transaction.
+pub fn withdraw_from_contract_to_obfuscated_gadget(
+    composer: &mut StandardComposer,
+    tx: &Transaction,
+    pk: &PublicKey,
+    change: &TransactionOutput,
+    send: &TransactionOutput,
+) {
+    // Fetch M
+    // TODO: fetch M
+    // Prove knowledge of commitment to m
+    // Prove message m is in range
+
+    if change.value > 0 {
+        // Prove the knowledge of commitment to change message
+        gadgets::commitment(composer, change);
+        // Prove change message is in range
+        gadgets::range(composer, change);
+    }
+
+    if send.value > 0 {
+        // Prove the knowledge of commitment to send message
+        gadgets::commitment(composer, send);
+        // Prove send message is in range
+        gadgets::range(composer, send);
+    }
+ 
+
+   
+    // Message - change - send = 0
+    let mut outputs: Vec<TransactionOutput> = vec![];
+    tx.outputs().iter().for_each(|output| {
+        outputs.push(*output);
+    });
+    outputs.push(*tx.fee());
+    if change.value > 0 {
+        outputs.push(*change);
+    }
+
+    if send.value > 0 {
+        outputs.push(*send);
+    }
+
+    // TODO: use M as inputs
+    // let mut sum = gadgets::balance(composer, m, &outputs);
+
+    // composer.constrain_to_constant(sum, BlsScalar::zero(), BlsScalar::zero());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto, Note, NoteGenerator, ObfuscatedNote, SecretKey, Transaction, TransparentNote,
+    };
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::fft::EvaluationDomain;
+    use merlin::Transcript;
+
+    #[test]
+    fn test_withdraw_obfuscated() {
+        let mut tx = Transaction::default();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 100;
+        let note = ObfuscatedNote::output(&pk, value).0;
+        let merkle_opening = crypto::MerkleProof::mock(note.hash());
+        tx.push_input(note.to_transaction_input(merkle_opening, sk).unwrap())
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 95;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        tx.push_output(note.to_transaction_output(value, blinding_factor, pk))
+            .unwrap();
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 2;
+        let (note, blinding_factor) = ObfuscatedNote::output(&pk, value);
+        let remainder = note.to_transaction_output(value, blinding_factor, pk);
+
+        let sk = SecretKey::default();
+        let pk = sk.public_key();
+        let value = 3;
+        let (note, blinding_factor) = TransparentNote::output(&pk, value);
+        tx.set_fee(note.to_transaction_output(value, blinding_factor, pk));
+
+        let mut composer = StandardComposer::new();
+
+        withdraw_from_contract_obfuscated_gadget(&mut composer, &tx, &pk, &remainder);
+
+        composer.add_dummy_constraints();
+
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let circuit = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &circuit, &mut transcript.clone());
+
+        assert!(proof.verify(&circuit, &mut transcript, &vk, &composer.public_inputs()));
+    }
+}


### PR DESCRIPTION
The specifications for the inner workings of the confidential token circuits has been implemented in this commit. They build on the gadgets previously merged. This closes #62. 